### PR TITLE
Typed events, Logging and Autocomplete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ temp
 .fake
 .vs
 *.js
+*.bak
+*.npmignore

--- a/build.fsx
+++ b/build.fsx
@@ -17,8 +17,8 @@ open Fake.ZipHelper
 #else
 #load "src/atom-bindings.fsx"
 #load "src/Core/Control.fs"
-#load "src/Core/Events.fs"
 #load "src/Core/DTO.fs"
+#load "src/Core/Events.fs"
 #load "src/Core/LanguageService.fs"
 #load "src/Components/Parser.fs"
 #load "src/Components/CompletionHelpers.fs"

--- a/src/Components/Autocomplete.fs
+++ b/src/Components/Autocomplete.fs
@@ -140,7 +140,7 @@ let createHelptextToolTip (overloads:DTO.OverloadSignature[]) (position:JQueryCo
 // Editor integration
 // --------------------------------------------------------------------------------------
 
-/// Triggered when we want to try register 
+/// Triggered to ensure that event handlers for autocomplete-plus are registered
 let checkAutoCompleteManager = Event<unit>()
 
 /// State-less getSuggestion function that is called by Atom

--- a/src/Components/DeveloperMode.fs
+++ b/src/Components/DeveloperMode.fs
@@ -7,9 +7,16 @@ open FunScript.TypeScript.fs
 open FunScript.TypeScript.child_process
 open FunScript.TypeScript.AtomCore
 open FunScript.TypeScript.text_buffer
+open FunScript.TypeScript.util
 
 open Atom
 open Atom.FSharp
+
+module Util =
+    [<JSEmitInline("util.format.apply(util, {0})")>]
+    let format (args:obj[]) : string = failwith "!"
+    [<JSEmitInline("console.log.apply(console, {0})")>]
+    let log (args:obj[]) : unit = failwith "!"
 
 [<ReflectedDefinition>]
 module DeveloperMode =
@@ -17,16 +24,28 @@ module DeveloperMode =
     let mutable editor : IEditor option = None
     let mutable log = ""
     let private subscriptions = ResizeArray()
+    let mutable logToConsole = true
 
     let activate () =
         let p = Globals.atom.project.getPaths().[0]
-        let s = Events.on Events.Log (unbox<Function> (fun (name,data) ->
-            let timeString = System.DateTime.Now.ToLongTimeString().Replace("\\",".").Replace("/", ".")
-            let t = (sprintf "[%s] %s: \n" timeString name) + data + "\n"
-            Globals.appendFile (p + "/.ionide.debug", t)
+        let s = Events.subscribe Events.Log (fun (category, message, data) ->
+            
+            if logToConsole then
+                let msg = "[" + (category.ToUpper()) + "] " + message
+                if data.Length = 0 then Globals.console.log(msg)
+                else Util.log (Array.append [| box msg |] data)
 
-            editor |> Option.iter (fun e -> e.getBuffer().append t |> ignore)
-            log <- log + t))
+            let timeString = System.DateTime.Now.ToLongTimeString().Replace("\\",".").Replace("/", ".")
+            
+            let msg = "[" + timeString + "] " + (category.ToUpper()) + "\n  " + (message.Replace("%O", "%s"))
+            let logLine = (Util.format (Array.append [| box msg |] data)) + "\n"
+            Globals.appendFile (p + "/.ionide.debug", logLine)
+            
+            editor |> Option.iter (fun e -> 
+              e.scrollToBufferPosition([| e.getLastBufferRow(); 0.0 |], null) |> ignore
+              e.getBuffer().append logLine |> ignore)
+            log <- log + logLine)
+
         subscriptions.Add s
 
         let s2 = Globals.atom.commands.add("atom-workspace", "Debug:Show Log", (unbox<Function> (fun _ ->

--- a/src/Components/Errors.fs
+++ b/src/Components/Errors.fs
@@ -27,7 +27,7 @@ module ErrorLinterProvider =
 
     let lint (editor : IEditor) =
         Atom.Promise.create(fun () ->
-            Events.once Events.Errors (fun (n : DTO.ParseResult) ->
+            Events.once Events.Errors (fun n ->
                 let map (item : DTO.Error) =
                     let range = [|[|float (item.StartLine - 1); float (item.StartColumn - 1)|];
                                   [|float (item.EndLine - 1);  float (item.EndColumn - 1)|]|]
@@ -45,7 +45,7 @@ module ErrorLinterProvider =
 
     let lintWarning (editor: IEditor) =
         Atom.Promise.create(fun () ->
-            Events.once Events.Lint (fun (n: DTO.LintResult) ->
+            Events.once Events.Lint (fun n ->
                 let map (item : DTO.Lint) =
                     let range = [|[|float (item.Range.StartLine - 1); float (item.Range.StartColumn - 1)|];
                                   [|float (item.Range.EndLine - 1);  float (item.Range.EndColumn - 1)|]|]

--- a/src/Components/FindDeclaration.fs
+++ b/src/Components/FindDeclaration.fs
@@ -17,15 +17,17 @@ module FindDeclaration =
     let mutable lastPosition : TextBuffer.IPoint option = None
 
     let private openDec (data : DTO.FindDeclarationResult) =
-        Globals.atom.workspace._open(data.Data.File, {OpenOptions.initialColumn = (data.Data.Column - 1); OpenOptions.initialLine = (data.Data.Line - 1) })
+        let oopts = 
+          { OpenOptions.initialColumn = (data.Data.Column - 1)
+            OpenOptions.initialLine = (data.Data.Line - 1) }
+        Globals.atom.workspace._open(data.Data.File, oopts) |> ignore
 
     let private goBack () =
-        lastFile |> Option.iter (fun lf ->
-        lastPosition |> Option.iter (fun lp ->
-            Globals.atom.workspace._open(lf, {OpenOptions.initialColumn = int lp.column; OpenOptions.initialLine = int lp.row })
-            |> ignore
-                 )
-            )
+        match lastFile, lastPosition with
+        | Some lf, Some lp ->
+            let oopts = { OpenOptions.initialColumn = int lp.column; OpenOptions.initialLine = int lp.row }
+            Globals.atom.workspace._open(lf, oopts) |> ignore
+        | _ -> ()
 
     let private handle e =
         let editor = Globals.atom.workspace.getActiveTextEditor()

--- a/src/Components/HighlightUse.fs
+++ b/src/Components/HighlightUse.fs
@@ -63,7 +63,7 @@ module HighlightUse =
     let activate () =
         Globals.atom.workspace.getActiveTextEditor() |> initialize
         Globals.atom.workspace.onDidChangeActivePaneItem((fun ed -> initialize ed) |> unbox<Function>  ) |> ignore
-        let tb = unbox<Function> showHighlight |> Events.on Events.SymbolUse
+        let tb = showHighlight |> Events.subscribe Events.SymbolUse
         subscriptions.Add tb
 
     let deactivate () =

--- a/src/Components/Toolbar.fs
+++ b/src/Components/Toolbar.fs
@@ -105,7 +105,7 @@ module ToolbarHandler =
         let tp = Globals.atom.workspace.onDidChangeActivePaneItem((fun ed -> handleEditorChange b ed) |> unbox<Function>  )
         subscriptions.Add tp
 
-        let tb = unbox<Function> cursorHandler |> Events.on Events.Toolbars
+        let tb = cursorHandler |> Events.subscribe Events.Toolbars
         subscriptions.Add tb
 
         ()

--- a/src/Components/Tooltips.fs
+++ b/src/Components/Tooltips.fs
@@ -139,9 +139,9 @@ module TooltipHandler =
     let activate () =
         Globals.atom.workspace.getActiveTextEditor() |> initialize
         Globals.atom.workspace.onDidChangeActivePaneItem((fun ed -> initialize ed ) |> unbox<Function>) |> ignore
-        let tt = unbox<Function> mouseHandler |> Events.on Events.Tooltips
+        let tt = mouseHandler |> Events.subscribe Events.Tooltips
         subscriptions.Add tt
-        let err = unbox<Function> errorHandler |> Events.on Events.Errors
+        let err = errorHandler |> Events.subscribe Events.Errors
         subscriptions.Add err
         ()
 

--- a/src/Core/Control.fs
+++ b/src/Core/Control.fs
@@ -1,15 +1,32 @@
 [<ReflectedDefinition>]
 module Atom.FSharp.Control
 
+open FunScript.TypeScript
+open FunScript.TypeScript.AtomCore
+
 // --------------------------------------------------------------------------------------
 // JavaScript-friendly implementation of some of the useful FSharp.Control types
 // --------------------------------------------------------------------------------------
 
+type FunScript.TypeScript.AtomCore.IEmitter with
+    /// Add a handler for the specified event forever
+    member x.add(name:string, func:unit -> unit) =
+        x.on(name, unbox<Function> func) |> ignore
+    /// Add a handler for the specified event and return disposable subscription
+    member x.subscribe(name:string, func:unit -> unit) =
+        x.on(name, unbox<Function> func) 
+
+type FunScript.TypeScript.AtomCore.CommandRegistry with 
+    /// Add a handler for the specified command forever
+    member x.add(name:string, command:string, func:unit -> unit) =
+        x.add(name, command, unbox<Function> func) |> ignore
+
+/// A simple implementation of `IObserver` that calls the specified functions
 type Observer<'T>(next, error, completed) = 
-  interface System.IObserver<'T> with
-    member x.OnCompleted() = completed()
-    member x.OnError(e) = error e
-    member x.OnNext(v) = next v
+    interface System.IObserver<'T> with
+        member x.OnCompleted() = completed()
+        member x.OnError(e) = error e
+        member x.OnNext(v) = next v
 
 type Microsoft.FSharp.Control.Async with
   /// Returns an asynchronous workflow that waits for the first 

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -46,8 +46,8 @@
   <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <ItemGroup>
     <Compile Include="Core\Control.fs" />
-    <Compile Include="Core\Events.fs" />
     <Compile Include="Core\DTO.fs" />
+    <Compile Include="Core\Events.fs" />
     <Compile Include="Core\LanguageService.fs" />
     <Compile Include="Components\Parser.fs" />
     <Compile Include="Components\UnicodeGlyphs.fs" />

--- a/src/main.fs
+++ b/src/main.fs
@@ -71,6 +71,7 @@ let translateModules fileName =
         yield "window.$ = require('jquery');"
         yield "var atomSpaceView = require('atom-space-pen-views');"
         yield "var fs = require('fs');"
+        yield "var util = require('util');"
         yield "var path = require('path');"
         yield "var Emitter = require('event-kit').Emitter;"
         yield ""


### PR DESCRIPTION
### Logging

I tweaked the logging so that it also logs to Atom's dev console (as well as to the file). The nice thing is that you can log objects that you can click through to see the details. 

![console](https://cloud.githubusercontent.com/assets/485413/12656546/c3df638c-c5f6-11e5-9117-7b6f7008be49.png)

### Autocomplete

Finished the async changes - I followed the same async pattern for registering handlers when switching between editor windows and I extracted the code to register scrolling handlers for autocomplete-plus into `registerCompletionScrollHandlers`. This was called on the first `Ctrl+Space`, but it seems that `autocomplete-plus` is already loaded when `create` is called, so we can just call it immediately (which fixes #200).

### Events & language service
I changed the events from a discriminated union to be values of a new `Event<T>` type. The result is that `Event.on` is now more type safe because the handler for `Event<'T>` is a function `'T -> unit` and so most of the code stays, but we can remove some type annotations :-).

I also removed some of the `unbox<Function>` stuff and added a wrapper `add` and `subscribe` for the most common uses.

In the parsing of events from language service, I removed the business with `last` (leftover from the standard I/O days :)) and I also tweaked the triggering of new events - and added more logging.
